### PR TITLE
Vel test

### DIFF
--- a/rover/src/owr_drive_controls/include/cmdVelToJoints.hpp
+++ b/rover/src/owr_drive_controls/include/cmdVelToJoints.hpp
@@ -37,6 +37,6 @@ class CmdVelToJoints {
         
         double frontLeftMotorV, frontRightMotorV, backLeftMotorV, backRightMotorV;
         double frontLeftAng, frontRightAng;
-        
-    
+        double backLeftAng, backRightAng;
+
 };

--- a/rover/src/owr_drive_controls/src/BoardControl.cpp
+++ b/rover/src/owr_drive_controls/src/BoardControl.cpp
@@ -379,6 +379,10 @@ void BoardControl::run() {
             //TODO: when using encoders s.enc0 was fliped, check this is not the case for pot
             frontLeftSwervePotMonitor.updatePos(s.swerveLeft, lastUpdate);
             frontRightSwervePotMonitor.updatePos(s.swerveRight, lastUpdate);
+            
+            // backLeftSwervePotMonitor.updatePos(s.swerveLeft, lastUpdate);
+            // backRightSwervePotMonitor.updatePos(s.swerveRight, lastUpdate);
+            
             armRotationBasePotMonitor.updatePos(s.pot0, lastUpdate);
             
             if(firstRun) {
@@ -388,8 +392,8 @@ void BoardControl::run() {
             }
             //do joint calculations
             // TODO Restore this before committing to master    
-            // swerveMotorVels swerveState = doVelTranslation(&(currentVel));
-            swerveMotorVels swerveState = doCrabTranslation(&(currentVel));
+            swerveMotorVels swerveState = doVelTranslation(&(currentVel));
+            // swerveMotorVels swerveState = doCrabTranslation(&(currentVel));
 
             pwmFLW = frontLeftWheel.velToPWM(swerveState.frontLeftMotorV);
             pwmFRW = frontRightWheel.velToPWM(swerveState.frontRightMotorV);

--- a/rover/src/owr_drive_controls/src/BoardControl.cpp
+++ b/rover/src/owr_drive_controls/src/BoardControl.cpp
@@ -234,7 +234,7 @@ BoardControl::BoardControl() :
     currentVel.linear.x = 0;
     currentVel.linear.y = 0;
     currentVel.linear.z = 0;
-    
+
     //swerve setup
     jMonitor.addJoint(&frontLeftWheel);
     jMonitor.addJoint(&frontRightWheel);
@@ -242,6 +242,8 @@ BoardControl::BoardControl() :
     jMonitor.addJoint(&backRightWheel);
     jMonitor.addJoint(&frontLeftSwerve);
     jMonitor.addJoint(&frontRightSwerve);
+    jMonitor.addJoint(&backRightSwerve);
+    jMonitor.addJoint(&backLeftSwerve);
     jMonitor.addJoint(&lidar);
     jMonitor.addJoint(&armBaseRotate);
     jMonitor.addJoint(&armLowerAct);
@@ -385,7 +387,10 @@ void BoardControl::run() {
                 firstRun = false;
             }
             //do joint calculations
-            swerveMotorVels swerveState = doVelTranslation(&(currentVel));
+            // TODO Restore this before committing to master    
+            // swerveMotorVels swerveState = doVelTranslation(&(currentVel));
+            swerveMotorVels swerveState = doCrabTranslation(&(currentVel));
+
             pwmFLW = frontLeftWheel.velToPWM(swerveState.frontLeftMotorV);
             pwmFRW = frontRightWheel.velToPWM(swerveState.frontRightMotorV);
             pwmBLW = backLeftWheel.velToPWM(swerveState.backLeftMotorV);
@@ -393,6 +398,9 @@ void BoardControl::run() {
             //TODO: this should actually be the angle from the encoders
             pwmFRS = frontRightSwerve.posToPWM(frontRightSwervePotMonitor.getPosition(), updateRateHZ);
             pwmFLS =  frontLeftSwerve.posToPWM(-frontLeftSwervePotMonitor.getPosition(), updateRateHZ);
+            pwmBRS = backRightSwerve.posToPWM(backRightSwervePotMonitor.getPosition(), updateRateHZ);
+            pwmBLS =  backLeftSwerve.posToPWM(-backLeftSwervePotMonitor.getPosition(), updateRateHZ);
+
             pwmLIDAR = lidar.velToPWM(updateRateHZ);
             
             //adjust the arm position

--- a/rover/src/owr_drive_controls/src/cmdVelToJoints.cpp
+++ b/rover/src/owr_drive_controls/src/cmdVelToJoints.cpp
@@ -31,8 +31,8 @@ int main(int argc, char ** argv) {
 }
 
 CmdVelToJoints::CmdVelToJoints() {
-     ros::TransportHints transportHints = ros::TransportHints().tcpNoDelay();
-     cmdVelSub = nh.subscribe<geometry_msgs::Twist>(TOPIC,1, &CmdVelToJoints::reciveVelMsg , this, transportHints);
+    ros::TransportHints transportHints = ros::TransportHints().tcpNoDelay();
+    cmdVelSub = nh.subscribe<geometry_msgs::Twist>(TOPIC,1, &CmdVelToJoints::reciveVelMsg , this, transportHints);
      
     frontLeftDrive = nh.advertise<std_msgs::Float64>("/front_left_wheel_axel_controller/command",1,true);
     frontRightDrive = nh.advertise<std_msgs::Float64>("/front_right_wheel_axel_controller/command",1,true);
@@ -43,12 +43,14 @@ CmdVelToJoints::CmdVelToJoints() {
     backLeftSwerve = nh.advertise<std_msgs::Float64>("/back_left_swerve_controller/command",1,true);
     backRightSwerve = nh.advertise<std_msgs::Float64>("/back_right_swerve_controller/command",1,true);
     
-    frontLeftMotorV =0;
+    frontLeftMotorV = 0;
     frontRightMotorV = 0;
     backLeftMotorV = 0;
     backRightMotorV = 0;
     frontLeftAng = 0;
     frontRightAng = 0;
+    backLeftAng = 0;
+    backRightAng = 0;
 }
 
 void CmdVelToJoints::run() {
@@ -68,6 +70,10 @@ void CmdVelToJoints::run() {
         frontLeftSwerve.publish(msg);
         msg.data = frontLeftAng;
         frontRightSwerve.publish(msg);
+        msg.data = backLeftAng;
+        backLeftSwerve.publish(msg);
+        msg.data = backRightAng;
+        backRightSwerve.publish(msg);
         ros::spinOnce();
     }
 }
@@ -91,6 +97,9 @@ void CmdVelToJoints::reciveVelMsg ( const geometry_msgs::Twist::ConstPtr& velMsg
     backRightMotorV = vels.backRightMotorV;
     frontLeftAng = vels.frontLeftAng;
     frontRightAng = vels.frontRightAng;
+    backLeftAng = vels.backLeftAng;
+    backRightAng = vels.backRightAng;
+
     ROS_INFO("target %f,%f,%f. fl %f, fr %f, bl %f, br %f, fls %f, frs %f", velMsg->linear.x, velMsg->linear.y, velMsg->linear.z, frontLeftMotorV, frontRightMotorV, backLeftMotorV, backRightMotorV, frontLeftAng, frontRightAng);
 }
 

--- a/rover/src/owr_drive_controls/src/swerveDrive.cpp
+++ b/rover/src/owr_drive_controls/src/swerveDrive.cpp
@@ -106,23 +106,16 @@ swerveMotorVels doVelTranslation(const geometry_msgs::Twist * velMsg) {
         // work out which side to favour
         if (0 <= turnAngle && turnAngle <= M_PI) {
             /* Turn Right */
-            output.frontLeftMotorV = closeFrontV;
-            output.backLeftMotorV = closeBackV;
-            output.frontRightMotorV = farFrontV;
-            output.backRightMotorV = farBackV;
-            output.frontLeftAng = closeFrontAng;
-            output.frontRightAng = farFrontAng;
-            ROS_INFO("right");
+            output = turn(output,
+                          closeFrontV, farFrontV, farBackV, closeBackV,
+                          closeFrontAng, farFrontAng,
+                          RIGHT);
         } else {
             /* Turn Left */
-            output.frontRightMotorV = -closeFrontV;
-            output.backRightMotorV = -closeBackV;
-            output.frontLeftMotorV = -farFrontV;
-            output.backLeftMotorV = -farBackV;
-            output.frontLeftAng = -farFrontAng;
-            output.frontRightAng = -closeFrontAng;
-            ROS_INFO("left");
-        }
+            output = turn(output,
+                          closeFrontV, farFrontV, farBackV, closeBackV,
+                          closeFrontAng, farFrontAng,
+                          LEFT);
     } else {
         // y = 0
         ROS_INFO("drive straight");

--- a/rover/src/owr_drive_controls/src/swerveDrive.cpp
+++ b/rover/src/owr_drive_controls/src/swerveDrive.cpp
@@ -28,25 +28,7 @@ swerveMotorVels turn(swerveMotorVels,
                      double,
                      int dir);
 
-
-swerveMotorVels turn(swerveMotorVels vels,
-                     double closeFrontV,
-                     double farFrontV,
-                     double farBackV,
-                     double closeBackV,
-                     double closeFrontAng,
-                     double farFrontAng,
-                     int dir) {
-
-    swerveMotorVels output = vels;
-    output.frontLeftMotorV = closeFrontV * dir;
-    output.backLeftMotorV = closeBackV * dir;
-    output.frontRightMotorV = farFrontV * dir;
-    output.backRightMotorV = farBackV * dir;
-    output.frontLeftAng =  output.backLeftAng = (closeFrontAng * dir);
-    output.frontRightAng = output.backRightAng = (farFrontAng * dir);
-    return output;
-}
+int getDir(double);
 
 
 swerveMotorVels doVelTranslation(const geometry_msgs::Twist * velMsg) {
@@ -55,7 +37,6 @@ swerveMotorVels doVelTranslation(const geometry_msgs::Twist * velMsg) {
     if (fabs(sqrt(pow(velMsg->linear.x, 2) + pow(velMsg->linear.y, 2))) < VEL_ERROR) {
         output.frontLeftMotorV = output.backLeftMotorV = 0;
         output.frontRightMotorV = output.backRightMotorV = 0;
-
         output.frontRightAng = output.frontLeftAng = 0;
     // account for the special case where y=0
     } else if (fabs(velMsg->linear.y) >= VEL_ERROR) {
@@ -104,19 +85,18 @@ swerveMotorVels doVelTranslation(const geometry_msgs::Twist * velMsg) {
         }
 
         // work out which side to favour
+        int dir;
         if (0 <= turnAngle && turnAngle <= M_PI) {
-            /* Turn Right */
-            output = turn(output,
-                          closeFrontV, farFrontV, farBackV, closeBackV,
-                          closeFrontAng, farFrontAng,
-                          RIGHT);
+            dir = RIGHT;
         } else {
-            /* Turn Left */
-            output = turn(output,
-                          closeFrontV, farFrontV, farBackV, closeBackV,
-                          closeFrontAng, farFrontAng,
-                          LEFT);
+            dir = LEFT;
         }
+        output.frontLeftMotorV = closeFrontV * dir;
+        output.backLeftMotorV = closeBackV * dir;
+        output.frontRightMotorV = farFrontV * dir;
+        output.backRightMotorV = farBackV * dir;
+        output.frontLeftAng = (closeFrontAng * dir);
+        output.frontRightAng = (farFrontAng * dir);
     } else {
         // y = 0
         ROS_INFO("drive straight");

--- a/rover/src/owr_drive_controls/src/swerveDrive.cpp
+++ b/rover/src/owr_drive_controls/src/swerveDrive.cpp
@@ -116,6 +116,7 @@ swerveMotorVels doVelTranslation(const geometry_msgs::Twist * velMsg) {
                           closeFrontV, farFrontV, farBackV, closeBackV,
                           closeFrontAng, farFrontAng,
                           LEFT);
+        }
     } else {
         // y = 0
         ROS_INFO("drive straight");

--- a/rover/src/owr_drive_controls/src/swerveDrive.cpp
+++ b/rover/src/owr_drive_controls/src/swerveDrive.cpp
@@ -128,61 +128,49 @@ swerveMotorVels doVelTranslation(const geometry_msgs::Twist * velMsg) {
     return output;
 }
 
+/**
+ * sqrt(x^2 + y^2)
+ */
+int getHypotenuse(int x, int y) {
+    return sqrt(pow(x, 2) + pow(y, 2));
+}
+
+
+int getVelMagnitude(const geometry_msgs::Twist * velMsg) {
+    return fabs(getHypotenuse(velMsg->linear.x, velMsg->linear.y));
+}
+
+swerveMotorVels stop(swerveMotorVels vels) {
+    swerveMotorVels output = vels;
+    output.frontLeftMotorV = output.backLeftMotorV = 0;
+    output.frontRightMotorV = output.backRightMotorV = 0;
+    output.frontRightAng = output.frontLeftAng = 0;
+    output.backRightAng = output.backLeftAng = 0;
+    return output;
+}
+
+
 
 swerveMotorVels doCrabTranslation(const geometry_msgs::Twist * velMsg) {
     swerveMotorVels output;
 
-    /**
-     * Questions:
-     * What is fab and where is it defined? How does it work?
-     * What does the ``Twist`` class look like? As of now, I can see that it
-     *      at least has
-     *          linear {x, y, z}
-     * What does x, y, and z of Twist entail?
-     */
-
     // santity check, if the magnitude is close to zero stop
-    if (fabs(sqrt(pow(velMsg->linear.x, 2) + pow(velMsg->linear.y, 2))) < VEL_ERROR) {
-        output.frontLeftMotorV = output.backLeftMotorV = 0;
-        output.frontRightMotorV = output.backRightMotorV = 0;
-        output.frontRightAng = output.frontLeftAng = 0;
+    int velMagnitude = getVelMagnitude(velMsg);
+    if (velMagnitude < VEL_ERROR) {
+        output = stop(output);
     // account for the special case where y = 0
     } else if (fabs(velMsg->linear.y) >= VEL_ERROR) {
         const double turnAngle = atan2(velMsg->linear.y, velMsg->linear.x);
-        const double rotationRadius = HALF_ROVER_WIDTH_X / sin(turnAngle);
-        geometry_msgs::Vector3 rotationCentre;
-        rotationCentre.x = -HALF_ROVER_WIDTH_X;
-        rotationCentre.y =
-            sqrt(pow(rotationRadius, 2) - pow(HALF_ROVER_WIDTH_X, 2));
-        // magnitude velocity over rotation radius
-        // const double angularVelocity =
-        //      (velMsg->linear.y / cos(turnAngle)) / rotationRadius;
-        const double angularVelocity =
-            fabs(sqrt(pow(velMsg->linear.x, 2) +
-            pow(velMsg->linear.y, 2))) / rotationRadius;
         ROS_INFO(
             "turnAngle %lf, rotationRadius %lf, rotationCenter  %lf, %lf, %lf",
             turnAngle, rotationRadius, rotationCentre.x, rotationCentre.y, rotationCentre.z);
-        // calculate the radiuses of each wheel about the rotation center
-        // NOTE: if necisary this could be optimised
-        double closeBackR = fabs(rotationCentre.y - ROVER_CENTRE_2_WHEEL_Y);
-        double farBackR = fabs(rotationCentre.y + ROVER_CENTRE_2_WHEEL_Y);
-        double closeFrontR = sqrt(pow(closeBackR, 2) + pow(FRONT_W_2_BACK_W_X, 2));
-        double farFrontR = sqrt(pow(farBackR, 2) + pow(FRONT_W_2_BACK_W_X, 2));
 
-        // V = wr
-        double closeBackV = closeBackR * angularVelocity;
-        double farBackV = farBackR * angularVelocity;
-        double closeFrontV = closeFrontR * angularVelocity;
-        double farFrontV = farFrontR * angularVelocity;
-
-        // work out the front wheel angles
-        double closeFrontAng = DEG90 - atan2(closeBackR, FRONT_W_2_BACK_W_X);
-        double farFrontAng = DEG90 - atan2(farBackR, FRONT_W_2_BACK_W_X);
+        // Setting all 
+        double closeFrontV = farFrontV = velMagnitude;
+        double farBackV = closeBackV = velMagnitude;
 
         // if we are in reverse,
         // we just want to go round the same circle in the opposite direction
-        // (I think...)
         if (velMsg->linear.x < 0) {
             // flip all the motorVs
             closeFrontV *=-1.0;
@@ -212,7 +200,6 @@ swerveMotorVels doCrabTranslation(const geometry_msgs::Twist * velMsg) {
         output.frontRightMotorV = output.backRightMotorV = velMsg->linear.x;
         output.frontRightAng = output.frontLeftAng = 0;
         output.backRightAng = output.backLeftAng = 0;
-        
     }
     return output;
 }

--- a/rover/src/owr_drive_controls/src/swerveDrive.cpp
+++ b/rover/src/owr_drive_controls/src/swerveDrive.cpp
@@ -123,6 +123,7 @@ swerveMotorVels doVelTranslation(const geometry_msgs::Twist * velMsg) {
         output.frontLeftMotorV = output.backLeftMotorV = velMsg->linear.x;
         output.frontRightMotorV = output.backRightMotorV = velMsg->linear.x;
         output.frontRightAng = output.frontLeftAng = 0;
+        output.backRightAng = output.backLeftAng = 0;
     }
     return output;
 }
@@ -210,6 +211,8 @@ swerveMotorVels doCrabTranslation(const geometry_msgs::Twist * velMsg) {
         output.frontLeftMotorV = output.backLeftMotorV = velMsg->linear.x;
         output.frontRightMotorV = output.backRightMotorV = velMsg->linear.x;
         output.frontRightAng = output.frontLeftAng = 0;
+        output.backRightAng = output.backLeftAng = 0;
+        
     }
     return output;
 }


### PR DESCRIPTION
- Added `backLeftAngle` and `backRightAngle` to the class `CmdVelToJoints`
- Draft implementation of `doCrabTranslation`
- Minor refactors and style tweaks
## Note
There is no ROS node listening for the topics that publish the back angles. That will be done in the main `RL-11` branch (which is `sajid/RL-11-crab-steer`)

