### PR TITLE
SV-15 publish the drive mode

### DIFF
--- a/rover/src/owr_drive_controls/include/cmdVelToJoints.hpp
+++ b/rover/src/owr_drive_controls/include/cmdVelToJoints.hpp
@@ -19,6 +19,11 @@
 
 
 #define TOPIC_VEL "/cmd_vel"
+
+// topic we send our current mode on
+#define TOPIC_MODE_PUB "/cmd_vel/mode"
+
+// topic we reciecve mode changes on
 #define TOPIC_MODE "/cmd_mode"
 
 enum driveMode {
@@ -41,6 +46,8 @@ class CmdVelToJoints {
         ros::NodeHandle nh;
         ros::Subscriber cmdDriveModeSub;
         ros::Subscriber cmdVelSub;
+
+        ros::Publisher modePub;
         
         ros::Publisher frontLeftDrive;
         ros::Publisher frontRightDrive;

--- a/rover/src/owr_drive_controls/src/cmdVelToJoints.cpp
+++ b/rover/src/owr_drive_controls/src/cmdVelToJoints.cpp
@@ -39,6 +39,8 @@ CmdVelToJoints::CmdVelToJoints() {
     ros::TransportHints transportHints = ros::TransportHints().tcpNoDelay();
     cmdDriveModeSub = nh.subscribe<std_msgs::Int16>(TOPIC_MODE, 1, &CmdVelToJoints::receiveDriveModeMsg, this, transportHints);
     cmdVelSub = nh.subscribe<geometry_msgs::Twist>(TOPIC_VEL, 1, &CmdVelToJoints::receiveVelMsg, this, transportHints);
+
+    modePub = nh.advertise<std_msgs::Int16>(TOPIC_MODE_PUB, 1, true);
      
     frontLeftDrive = nh.advertise<std_msgs::Float64>("/front_left_wheel_axel_controller/command",1,true);
     frontRightDrive = nh.advertise<std_msgs::Float64>("/front_right_wheel_axel_controller/command",1,true);
@@ -58,6 +60,10 @@ CmdVelToJoints::CmdVelToJoints() {
     frontRightAng = 0;
     backLeftAng = 0;
     backRightAng = 0;
+
+    std_msgs::Int16 modeMsg;
+    modeMsg.data = CRAB;
+    modePub.publish(modeMsg);
 }
 
 void CmdVelToJoints::run() {
@@ -117,6 +123,9 @@ driveMode CmdVelToJoints::getDriveMode() {
 
 void CmdVelToJoints::receiveDriveModeMsg(const std_msgs::Int16::ConstPtr& driveModeMsg) {
     mode = (driveMode) driveModeMsg->data;
+    std_msgs::Int16 outMsg;
+    outMsg.data = mode;
+    modePub.publish(outMsg);
     ROS_INFO("Drive mode = %d", (int) mode);
 }
 


### PR DESCRIPTION
Get the joint control node to publish the drive mode. This way is better then getting it from the joystick module as it will always be correct. 